### PR TITLE
ci: Enable junit output for the executed tests

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -31,4 +31,4 @@ Metacello new
 	load.
 "
 # execute tests
-./pharo Pharo.image test --no-xterm --fail-on-failure "$tests" 2>&1
+./pharo Pharo.image test --no-xterm --fail-on-failure --junit-xml-output "$tests" 2>&1


### PR DESCRIPTION
junit output allows to be analyzed further (e.g. like seen in the
smalltalkCI scripts).